### PR TITLE
Arch linux installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -261,6 +261,52 @@ sudo apt-get install gmt gmt-gshhg
 
 7. Make sure to also read the [post-installation steps](#linux-post-installation-steps).
 
+### Arch Linux
+
+GROOPS is packaged for the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+You can install the [groops-git](https://aur.archlinux.org/packages/groops-git/) package providing the core GROOPS executables,
+and the [groopsgui-git](https://aur.archlinux.org/packages/groopsgui-git/) package providing the GUI and documentation.
+
+The easiest way to do this is through an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). If you are using `yay`,
+for example, you can install GROOPS and the GUI by executing
+```
+yay -S groops-git groopsgui-git
+
+```
+
+If you want to develop for GROOPS, a manual installation is preferrable:
+
+1. First, make sure your system is up to date:
+    ```
+    sudo pacman -Syu
+    ```
+2. Install dependencies and build tools:
+    ```
+    sudo pacman -S git cmake gcc gcc-gfortran bash expat lapack zlib
+    ```
+3. *(Optional)* Install the NetCDF development package:
+    ```
+    sudo pacman -S netcdf-cxx
+    ```
+4. *(Optional)* Install liberfa development packages. liberfa is available as an [AUR package](https://aur.archlinux.org/packages/erfa/).
+
+5. *(Optional)* Install an MPI development package, eg. `openmpi`:
+    ```
+    sudo pacman -S openmpi
+    ```
+6. Fetch the GROOPS git repository:
+    ```
+    git clone https://github.com/groops-devs/groops.git
+    ```
+7. Create the build directory and compile GROOPS, Adjust the paths if you checked out the GROOPS git repository to a different directory.
+    ```
+    mkdir $HOME/groops/source/build && cd $HOME/groops/source/build
+    cmake ..
+    make
+    ```
+8. Make sure to also read the [post-installation steps](#linux-post-installation-steps).
+
+
 #### Graphical User Interface (GUI)
 
 The GROOPS GUI depends on Qt packages.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ This installation guide assumes that the GROOPS source code is located in `C:\gr
     mingw32-make.exe
     ```
 
-8. Make sure to also read the [post-installation steps](#windows-post-installation-steps)
+8. Make sure to also read the [post-installation steps](#windows-post-installation-steps).
 
 ### Graphical User Interface (GUI)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ This installation guide assumes that the GROOPS source code is located in `C:\gr
     mingw32-make.exe
     ```
 
-8. Make sure to also read the [post-installation steps](#windows-post-installation-steps).
+8. Make sure to also read the [post-installation steps](#windows-post-installation-steps)
 
 ### Graphical User Interface (GUI)
 
@@ -261,6 +261,32 @@ sudo apt-get install gmt gmt-gshhg
 
 7. Make sure to also read the [post-installation steps](#linux-post-installation-steps).
 
+#### Graphical User Interface (GUI)
+
+The GROOPS GUI depends on Qt packages.
+To install the required packages, run:
+```
+sudo zypper install libqt5-qtbase-devel
+```
+Then, change into the `gui` directory and compile the source code:
+```
+cd $HOME/groops/gui
+qmake-qt5
+make
+```
+
+#### Generic Mapping Tools (GMT)
+
+The OpenSUSE packages for the Generic Mapping Tools are available in the `GEO` repository
+(change OpenSUSE release version if necessary):
+```
+sudo zypper addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_15.2/ GEO
+```
+Then install the packages:
+```
+sudo zypper install GMT GMT-doc GMT-coastlines
+```
+
 ### Arch Linux
 
 GROOPS is packaged for the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository).
@@ -271,7 +297,6 @@ The easiest way to do this is through an [AUR helper](https://wiki.archlinux.org
 for example, you can install GROOPS and the GUI by executing
 ```
 yay -S groops-git groopsgui-git
-
 ```
 
 If you want to develop for GROOPS, a manual installation is preferrable:
@@ -306,32 +331,26 @@ If you want to develop for GROOPS, a manual installation is preferrable:
     ```
 8. Make sure to also read the [post-installation steps](#linux-post-installation-steps).
 
-
+```
 #### Graphical User Interface (GUI)
 
 The GROOPS GUI depends on Qt packages.
 To install the required packages, run:
 ```
-sudo zypper install libqt5-qtbase-devel
+sudo pacman  -S qt5-base
 ```
 Then, change into the `gui` directory and compile the source code:
 ```
 cd $HOME/groops/gui
-qmake-qt5
+qmake
 make
 ```
 
 #### Generic Mapping Tools (GMT)
 
-The OpenSUSE packages for the Generic Mapping Tools are available in the `GEO` repository
-(change OpenSUSE release version if necessary):
-```
-sudo zypper addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_15.2/ GEO
-```
-Then install the packages:
-```
-sudo zypper install GMT GMT-doc GMT-coastlines
-```
+The Generic Mapping Tools are available from the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+Install the [gmt6](https://aur.archlinux.org/packages/gmt6) and [gmt-coast](https://aur.archlinux.org/packages/gmt-coast) packages.
+
 
 ### Linux post-installation steps
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -331,7 +331,6 @@ If you want to develop for GROOPS, a manual installation is preferrable:
     ```
 8. Make sure to also read the [post-installation steps](#linux-post-installation-steps).
 
-```
 #### Graphical User Interface (GUI)
 
 The GROOPS GUI depends on Qt packages.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 add_executable(groops ${SOURCES} ${PROJECT_SOURCE_DIR}/parallel/parallelSingle.cpp)
 target_link_libraries(groops ${BASE_LIBRARIES})
 set_target_properties(groops PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/../bin")
+install(TARGETS groops DESTINATION bin)
 
 # =========================================
 
@@ -69,6 +70,7 @@ if(MPI_FOUND)
   if(MPI_LINK_FLAGS)
     set_target_properties(groopsMPI PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
   endif()
+  install(TARGETS groopsMPI DESTINATION bin)
 else()
   message(WARNING "A GROOPS executable for MPI parallel computing will *NOT* be created.")
 endif()


### PR DESCRIPTION
This PR provides installation instructions for Arch Linux, and marks groops binaries as explicit cmake installation targets. See #1 .