### PR TITLE
Fix typo in log function: ExpressionParser.cpp (line 678)

### DIFF
--- a/source/parser/expressionParser.cpp
+++ b/source/parser/expressionParser.cpp
@@ -675,7 +675,7 @@ class ExpressionLog : public ExpressionFunction1
 public:
   explicit ExpressionLog(const ExpressionPtr &ob) : ExpressionFunction1(ob) {}
   std::string   name() const override {return "log";}
-  ExpressionPtr create(const ExpressionPtr &ob) const override {return std::make_shared<ExpressionExp>(ob);}
+  ExpressionPtr create(const ExpressionPtr &ob) const override {return std::make_shared<ExpressionLog>(ob);}
   Double        evaluate(const VariableList &varList) const override {return std::log(operand->evaluate(varList));}
   ExpressionPtr derivative(const std::string &var) const override {return operand->derivative(var)^exprValue(-1);}
 };


### PR DESCRIPTION
Dear developers,
I found a typo in the expressionParser.cpp file, line 678.

I think it shoud be
`ExpressionPtr create(const ExpressionPtr &ob) const override {return std::make_shared<ExpressionLog>(ob);}`
instead of 
`ExpressionPtr create(const ExpressionPtr &ob) const override {return std::make_shared<ExpressionExp>(ob);}`

Hopefully this is helpful

Best
Giulia Schievano