### PR TITLE
Add or improve some docstring documentation

### DIFF
--- a/source/classes/tides/tidesDoodsonHarmonic.h
+++ b/source/classes/tides/tidesDoodsonHarmonic.h
@@ -34,7 +34,7 @@ $\Theta_f(t)$ are the arguments of the tide constituents~$f$:
 where $\beta_i(t)$ are the Doodson's fundamental arguments ($\tau,s,h,p,N',p_s$)
 and $n_f^i$ are the Doodson multipliers for the term at frequency~$f$.
 
-The major constituents given by \configFile{inputfileDoodsonHarmonic}{doodsonHarmonic} can be used to
+The major constituents given by \configFile{inputfileTides}{doodsonHarmonic} can be used to
 interpolate minor tidal constituents using the file \configFile{inputfileAdmittance}{admittance}.
 This file can be created with \program{DoodsonHarmonicsCalculateAdmittance}.
 

--- a/source/files/fileDoodsonHarmonic.h
+++ b/source/files/fileDoodsonHarmonic.h
@@ -19,12 +19,12 @@ static const char *docstringDoodsonHarmonic = R"(
 Ocean tides are represented as time variable gravitational potential
 and is given by a fourier expansion
 \begin{equation}
-V(\M x,t) = \sum_{f} V_f^c(\M x)\cos(\Theta_f(t)) + V_f^s(\M x)\sin(\Theta_f(t)),
+V(\M x,t) = \sum_{f} V_f^c(\M x)\cos(\theta_f(t)) + V_f^s(\M x)\sin(\theta_f(t)),
 \end{equation}
 where $V_f^c(\M x)$ and $V_f^s(\M x)$ are spherical harmonics.
-The $\Theta_f(t)$ are the arguments of the tide constituents $f$:
+The $\theta_f(t)$ are the arguments of the tide constituents $f$:
 \begin{equation}
-\Theta_f(t) = \sum_{i=1}^6 n_f^i\beta_i(t),
+\theta_f(t) = \sum_{i=1}^6 n_f^i\beta_i(t),
 \end{equation}
 where $\beta_i(t)$ are the Doodson's fundamental arguments ($\tau,s,h,p,N',p_s$) and $n_f^i$
 are the Doodson multipliers for the term at frequency~$f$.

--- a/source/slr/slrStationGenerator/slrStationGeneratorStations.h
+++ b/source/slr/slrStationGenerator/slrStationGeneratorStations.h
@@ -46,7 +46,7 @@ Tidal deformations typically include:
   \item \configClass{doodsonHarmonicTide}{tidesType:doodsonHarmonicTide}: atmospheric tidal deformation
         (e.g. AOD1B RL06, \config{minDegree}=\verb|1|)
   \item \configClass{poleTide}{tidesType:poleTide}: pole tidal deformations (IERS conventions)
-  \item \configClass{poleOceanTide}{tidesType:oceanPoleTide}: ocean pole tidal deformations (IERS conventions)
+  \item \configClass{oceanPoleTide}{tidesType:oceanPoleTide}: ocean pole tidal deformations (IERS conventions)
 \end{itemize}
 )";
 #endif


### PR DESCRIPTION
for example, the arguments of the tide constituents are in different cases at different files. The lower-case is chosen here to have better consistence with the IERS Convention document. 