### PR TITLE
Fix parallel initialization of GnssParametrizationLeoDynamicOrbits

### DIFF
--- a/source/gnss/gnssParametrization/gnssParametrizationLeoDynamicOrbits.cpp
+++ b/source/gnss/gnssParametrization/gnssParametrizationLeoDynamicOrbits.cpp
@@ -78,12 +78,13 @@ void GnssParametrizationLeoDynamicOrbits::init(Gnss *gnss, Parallel::Communicato
     for(UInt idRecv=0; idRecv<gnss->receivers.size(); idRecv++)
       if(selectedReceivers.at(idRecv) && gnss->receivers.at(idRecv)->useable())
       {
-        recvProcess(idRecv) = Parallel::myRank(comm)+1;
         auto para = new Parameter();
         parameters.at(idRecv) = para;
         para->recv = gnss->receivers.at(idRecv);
 
-        if(!para->recv->isMyRank())
+        if(para->recv->isMyRank())
+          recvProcess(idRecv) = Parallel::myRank(comm)+1;
+        else
           continue;
 
         // find first and last valid epoch


### PR DESCRIPTION
This fixes a crash of GROOPS when the parametrization LeoDynamicOrbits was used together with more than one process in GnssProcessing. The problem was that `recvProcess(idRecv)` was set to `Parallel::myRank(comm)+1` on every process and not just the one where `para->recv->isMyRank()`. The caused a crash later when `Parallel::broadCast` tried to synchronize the parameter names.