### PR TITLE
Return exit code 0 after displaying help text with -h

### DIFF
--- a/source/groops.cpp
+++ b/source/groops.cpp
@@ -82,7 +82,7 @@ GitHub repository: https://github.com/groops-devs/groops
 
 /***********************************************/
 
-static void groopsHelp(const std::string &progName, Parallel::CommunicatorPtr comm)
+static void groopsHelp(const std::string &progName, Parallel::CommunicatorPtr comm, UInt exitCode=EXIT_FAILURE)
 {
   if(Parallel::isMaster(comm))
   {
@@ -104,7 +104,7 @@ static void groopsHelp(const std::string &progName, Parallel::CommunicatorPtr co
     std::cout<<"GitHub repository: https://github.com/groops-devs/groops"<<std::endl;
     std::cout<<"(Compiled: "<<__DATE__<<" "<<__TIME__<<")"<<std::endl;
   }
-  exit(EXIT_FAILURE);
+  exit(exitCode);
 }
 
 /***********************************************/
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
         else if((opt == "-c") || (opt == "--settings"))       {settingsFileName      = FileName(optArg());}
         else if((opt == "-C") || (opt == "--write-settings")) {writeSettingsFileName = FileName(optArg());}
         else if((opt == "-s") || (opt == "--silent"))         {silent = TRUE;}
-        else if((opt == "-h") || (opt == "--help"))           {groopsHelp(argv[0], comm);}
+        else if((opt == "-h") || (opt == "--help"))           {groopsHelp(argv[0], comm, EXIT_SUCCESS);}
         else if((opt == "-g") || (opt == "--global"))
         {
           std::string keyVal(optArg());


### PR DESCRIPTION
When calling the application with `-h` to display the help text the return code was `EXIT_FAILURE`, even though this the intended use case and no error has occurred. The return code for this particular case is now changed to `EXIT_SUCCESS`.

It is not a big deal, but confused me a little when I was using `groops -h` for testing where I needed the application to do nothing else but terminate itself successfully.