### PR TITLE
More flexible math environments in documentation (HTML/MathJax)

### DIFF
--- a/docs/html/static/template.html
+++ b/docs/html/static/template.html
@@ -5,29 +5,34 @@
     <title>GROOPS - [[[title]]]</title>
 
     <!-- JQuery and Popper -->
-    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-4.0.0.slim.min.js" integrity="sha256-8DGpv13HIm+5iDNWw1XqxgFB4mj+yOKFNb+tHBZOowc=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 
     <!-- Bootstrap -->
     <!-- https://getbootstrap.com/docs/4.1/examples/ -->
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 
     <!-- Mathjax -->
-    <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({tex2jax: {inlineMath: [ ['$','$'] ],
-                                  displayMath: [ ["\\[","\\]"] ],
-                                  processEscapes: true},
-                        TeX:     {Macros: {M: ["{\\mathbf #1}",1]},
-                                  equationNumbers: {autoNumber: "all"}  }});
+    <script>
+    window.MathJax = {tex: {
+                          inlineMath: {'[+]': [['$', '$']]},
+                          displayMath: {'[+]': [['\\[', '\\]']]},
+                          macros: {
+                            M: ["{\\mathbf #1}", 1]
+                          },
+                          tags: 'ams',
+                          processEscapes: true
+                        }
+                      };
     </script>
-    <script async src="https://cdn.jsdelivr.net/npm/mathjax@2.7.7/MathJax.js?config=TeX-AMS_CHTML" integrity="sha384-e/4/LvThKH1gwzXhdbY2AsjR3rm7LHWyhIG5C0jiRfn8AN2eTN5ILeztWw0H9jmN" crossorigin="anonymous"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"></script>
 
     <!-- lunr -->
-    <script src="https://cdn.jsdelivr.net/npm/lunr@2.3.8/lunr.min.js" integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js" integrity="sha256-DFDZACuFeAqEKv/7Vnu1Tt5ALa58bcWZegGGFNgET8g=" crossorigin="anonymous"></script>
 
     <!-- Mustache -->
-    <script src="https://cdn.jsdelivr.net/npm/mustache@4.0.1/mustache.min.js" integrity="sha384-0PLEZVBpOQ+Kqw3anJWSNWvRxpEFt02tSpBvyRsA4WcvX/OTldWdXxGLVLvh954H" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mustache@4.2.0/mustache.min.js" integrity="sha256-1/0GA1EkYejtvYFoa+rSq4LfM4m5zKI13Z1bQIhI4Co=" crossorigin="anonymous"></script>
 
     <!-- GROOPS Stylesheet -->
     <link rel="stylesheet" href="static/groops.css"/>
@@ -57,11 +62,15 @@
                   </li>
                 </ul>
               </div>
-                <form class="form-inline my-2 my-lg-0" action="search.html" id="searchTools">
-                  <input class="form-control mr-sm-2" placeholder="Search" name="searchTerms" method="GET" value="" type="text" id="searchBox">
-                  <button class="btn btn-secondary my-2 my-sm-0" type="submit" id="searchButton">Search</button>
+                <form class="row row-cols-lg-auto g-2 align-items-center" action="search.html" id="searchTools">
+                  <div class="col-12">
+                    <input class="form-control my-sm-2" placeholder="Search" name="searchTerms" method="GET" value="" type="text" id="searchBox">
+                  </div>
+                  <div class="col-12">
+                    <button class="btn btn-secondary my-2 my-sm-0" type="submit" id="searchButton">Search</button>
+                  </div>
                 </form>
-              <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation" style="">
+              <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation" style="">
                 <span class="navbar-toggler-icon"></span>
               </button>
             </div>

--- a/source/config/generateDocumentation.cpp
+++ b/source/config/generateDocumentation.cpp
@@ -55,7 +55,7 @@ static _ClassGnssType _classGnssType;
 class Documentation::Token
 {
 public:
-  enum Type {TEXT, PARAGRAPH, NEWLINE, ESCAPE, BRACKET, COMMAND, EQUATION, EQUATIONINLINE};
+  enum Type {TEXT, PARAGRAPH, NEWLINE, ESCAPE, BRACKET, COMMAND, EQUATION, MATHINLINE, MATHDISPLAY};
   Type        type;
   std::string text;
   std::vector<std::string> options;
@@ -130,12 +130,12 @@ std::vector<Documentation::Token> Documentation::tokenize(const std::string &tex
           pos = posTmp;
         }
       }
-      else if(text.at(pos) == '$') // EQUATIONINLINE
+      else if(text.at(pos) == '$') // MATHINLINE
       {
         auto posTmp = text.find('$', ++pos);
         if(posTmp == std::string::npos)
           throw(Exception("missing '$'"));
-        tokens.push_back(Token(Token::EQUATIONINLINE, text.substr(pos, posTmp-pos)));
+        tokens.push_back(Token(Token::MATHINLINE, text.substr(pos, posTmp-pos)));
         pos = posTmp+1;
       }
       else if(text.at(pos) == '\\')
@@ -143,12 +143,12 @@ std::vector<Documentation::Token> Documentation::tokenize(const std::string &tex
         pos++;
         if(pos >= text.size())
           throw(Exception("text ended unexpectedly after '\\'"));
-        if(text.at(pos) == '[') // EQUATION
+        if(text.at(pos) == '[') // MATHDISPLAY
         {
           auto posTmp = text.find(R"(\])", ++pos);
           if(posTmp == std::string::npos)
             throw(Exception("missing '\\]'"));
-          tokens.push_back(Token(Token::EQUATION, text.substr(pos, posTmp-pos)));
+          tokens.push_back(Token(Token::MATHDISPLAY, text.substr(pos, posTmp-pos)));
           pos = posTmp+2;
         }
         else if(text.at(pos) == '\\')        // NEWLINE
@@ -545,8 +545,9 @@ void DocumentationHtml::writeText(const std::string &text)
       switch(token.at(i).type)
       {
         case Token::TEXT:           html = text; addToSearchTokens(text); break;
-        case Token::EQUATIONINLINE: html = "$"+text+"$"; break;
-        case Token::EQUATION:       html = "\\["+ text +"\\]"; break;
+        case Token::MATHINLINE:     html = "$"+text+"$"; break;
+        case Token::MATHDISPLAY:    html = "\\["+ text +"\\]"; break;
+        case Token::EQUATION:       html = "\\begin{equation}"+ text +"\\end{equation}"; break;
         case Token::ESCAPE:         html = text; break;
         case Token::PARAGRAPH:      html = "</p><p>"; break;
         case Token::NEWLINE:

--- a/source/gnss/gnssParametrization/gnssParametrizationIonosphereSTEC.h
+++ b/source/gnss/gnssParametrization/gnssParametrizationIonosphereSTEC.h
@@ -25,11 +25,12 @@ This is similar to using the ionosphere-free linear combination as observations
 but only one STEC parameter is needed for an arbitrary number of observation types.
 
 The influence on the code and phase observation is modeled as
-\begin{equation}\label{gnssParametrizationType:IonosphereSTEC:STEC}
+\begin{equation}
 \begin{split}
 \text{ionosphere}([C\nu], STEC) &=  \frac{40.3}{f_{\nu}^2}STEC + \frac{7525\M b^T\M k}{f_{\nu}^3}STEC +  \frac{r}{f_{\nu}^4}STEC^2 \\
 \text{ionosphere}([L\nu], STEC) &= -\frac{40.3}{f_{\nu}^2}STEC - \frac{7525\M b^T\M k}{2f_{\nu}^3}STEC - \frac{r}{3f_{\nu}^4}STEC^2 + \text{bending}(E)STEC^2
 \end{split}
+\label{gnssParametrizationType:IonosphereSTEC:STEC}
 \end{equation}
 The second order term depends on the \configClass{magnetosphere}{magnetosphereType} $\M b$
 and the direction of the signal $\M k$.


### PR DESCRIPTION
Dear GROOPS Team,

this PR updates two components of the GROOPS documentation generation:
- it introduces latex inline math and display math environments,
- it updates the JavaScript dependencies in the HTML documentation template to the latest versions

This addresses issue #432.

 Best,
Andreas