### PR TITLE
Rename config elements with typos

### DIFF
--- a/groops.xsd
+++ b/groops.xsd
@@ -5281,6 +5281,8 @@
 			<xs:element name="radiationPressure">
 				<xs:annotation>
 					<xs:documentation>Solar and Earh radiation pressure model</xs:documentation>
+					<xs:appinfo>rename: factorSolarRadation = factorSolarRadiation</xs:appinfo>
+					<xs:appinfo>rename: factorEarthRadation = factorEarthRadiation</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
@@ -5300,12 +5302,12 @@
 								<xs:documentation>GriddedDataTimeSeries of longwave flux values [W/m^2]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="factorSolarRadation" type="double" minOccurs="0" default="1.0">
+						<xs:element name="factorSolarRadiation" type="double" minOccurs="0" default="1.0">
 							<xs:annotation>
 								<xs:documentation>Solar radiation pressure is multiplied by this factor</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="factorEarthRadation" type="double" minOccurs="0" default="1.0">
+						<xs:element name="factorEarthRadiation" type="double" minOccurs="0" default="1.0">
 							<xs:annotation>
 								<xs:documentation>Earth radiation preussure is multiplied by this factor</xs:documentation>
 							</xs:annotation>
@@ -16696,6 +16698,7 @@
 			<xs:element name="Kernel2Coefficients">
 				<xs:annotation>
 					<xs:documentation>compute kernel coefficients</xs:documentation>
+					<xs:appinfo>rename: maxDegre = maxDegree</xs:appinfo>
 					<xs:appinfo>tag: Misc</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -16711,7 +16714,7 @@
 								<xs:documentation>minimum degree of returned coefficients</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="maxDegre" type="uint">
+						<xs:element name="maxDegree" type="uint">
 							<xs:annotation>
 								<xs:documentation>compute coefficients up to maxDegree</xs:documentation>
 							</xs:annotation>
@@ -17375,6 +17378,10 @@
 									<xs:element name="mass" type="double"/>
 									<xs:element name="coefficientDrag" type="double"/>
 									<xs:element name="surfaces">
+										<xs:annotation>
+											<xs:appinfo>rename: reflexionInfrared = reflectionInfrared</xs:appinfo>
+											<xs:appinfo>rename: reflexionVisible = reflectionVisible</xs:appinfo>
+										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="inputfile" type="filename">
@@ -17395,10 +17402,10 @@
 												<xs:element name="normalX" type="expression" default="data1"/>
 												<xs:element name="normalY" type="expression" default="data2"/>
 												<xs:element name="normalZ" type="expression" default="data3"/>
-												<xs:element name="reflexionVisible" type="expression" default="data4"/>
+												<xs:element name="reflectionVisible" type="expression" default="data4"/>
 												<xs:element name="diffusionVisible" type="expression" default="data5"/>
 												<xs:element name="absorptionVisible" type="expression" default="data6"/>
-												<xs:element name="reflexionInfrared" type="expression" default="data7"/>
+												<xs:element name="reflectionInfrared" type="expression" default="data7"/>
 												<xs:element name="diffusionInfrared" type="expression" default="data8"/>
 												<xs:element name="absorptionInfrared" type="expression" default="data9"/>
 												<xs:element name="specificHeatCapacity" type="expression" default="data10">
@@ -21737,6 +21744,7 @@
 			<xs:element name="DoodsonHarmonics2IersPotential">
 				<xs:annotation>
 					<xs:documentation>convert doodson harmonics file to IERS</xs:documentation>
+					<xs:appinfo>rename: inputfileDoodsonHarmoncis = inputfileDoodsonHarmonics</xs:appinfo>
 					<xs:appinfo>tag: Conversion</xs:appinfo>
 					<xs:appinfo>tag: DoodsonHarmonics</xs:appinfo>
 				</xs:annotation>
@@ -21747,7 +21755,7 @@
 								<xs:documentation>according to IERS2010, chapter 6.3.2, footnote 7</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="inputfileDoodsonHarmoncis" type="filename"/>
+						<xs:element name="inputfileDoodsonHarmonics" type="filename"/>
 						<xs:element name="header" type="string" default="[&quot;Coefficients to compute variations in normalized Stokes coefficients (unit = 10^-11)&quot;, &quot;Ocean tide model: FES2014b up to (100,100) in cm&quot;]" maxOccurs="unbounded">
 							<xs:annotation>
 								<xs:documentation>info for output header</xs:documentation>
@@ -21762,6 +21770,7 @@
 			<xs:element name="DoodsonHarmonics2IersWaterHeight">
 				<xs:annotation>
 					<xs:documentation>convert doodson harmonics file to IERS</xs:documentation>
+					<xs:appinfo>rename: inputfileDoodsonHarmoncis = inputfileDoodsonHarmonics</xs:appinfo>
 					<xs:appinfo>tag: Conversion</xs:appinfo>
 					<xs:appinfo>tag: DoodsonHarmonics</xs:appinfo>
 				</xs:annotation>
@@ -21772,7 +21781,7 @@
 								<xs:documentation>according to IERS2010, chapter 6.3.2, footnote 7</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="inputfileDoodsonHarmoncis" type="filename"/>
+						<xs:element name="inputfileDoodsonHarmonics" type="filename"/>
 						<xs:element name="inputfileTideGeneratingPotential" type="filename" default="{groopsDataDir}/tides/generatingTide_HW95.txt">
 							<xs:annotation>
 								<xs:documentation>to compute Xi phase correction</xs:documentation>
@@ -22380,6 +22389,7 @@
 			<xs:element name="GnssReceiver2RinexObservation">
 				<xs:annotation>
 					<xs:documentation>Converts GnssReceiver Instrument file to RINEX.</xs:documentation>
+					<xs:appinfo>rename: angency = agency</xs:appinfo>
 					<xs:appinfo>tag: Conversion</xs:appinfo>
 					<xs:appinfo>tag: Gnss</xs:appinfo>
 					<xs:appinfo>tag: Instrument</xs:appinfo>
@@ -22411,7 +22421,7 @@
 								<xs:documentation>header information</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="angency" type="string" minOccurs="0" default="TUG">
+						<xs:element name="agency" type="string" minOccurs="0" default="TUG">
 							<xs:annotation>
 								<xs:documentation>header information</xs:documentation>
 							</xs:annotation>
@@ -24196,12 +24206,13 @@
 			<xs:element name="IersPotential2DoodsonHarmonics">
 				<xs:annotation>
 					<xs:documentation>Read ocean tide file in IERS format</xs:documentation>
+					<xs:appinfo>rename: outputfileDoodsonHarmoncis = outputfileDoodsonHarmonics</xs:appinfo>
 					<xs:appinfo>tag: Conversion</xs:appinfo>
 					<xs:appinfo>tag: DoodsonHarmonics</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="outputfileDoodsonHarmoncis" type="filename"/>
+						<xs:element name="outputfileDoodsonHarmonics" type="filename"/>
 						<xs:element name="inputfile" type="filename"/>
 						<xs:element name="headerLines" type="uint" default="4">
 							<xs:annotation>
@@ -24252,12 +24263,13 @@
 			<xs:element name="IersWaterHeight2DoodsonHarmonics">
 				<xs:annotation>
 					<xs:documentation>Read ocean tide file in IERS format</xs:documentation>
+					<xs:appinfo>rename: outputfileDoodsonHarmoncis = outputfileDoodsonHarmonics</xs:appinfo>
 					<xs:appinfo>tag: Conversion</xs:appinfo>
 					<xs:appinfo>tag: DoodsonHarmonics</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="outputfileDoodsonHarmoncis" type="filename"/>
+						<xs:element name="outputfileDoodsonHarmonics" type="filename"/>
 						<xs:element name="inputfile" type="filename"/>
 						<xs:element name="headerLines" type="uint" default="3">
 							<xs:annotation>

--- a/source/classes/miscAccelerations/miscAccelerationsRadiationPressure.h
+++ b/source/classes/miscAccelerations/miscAccelerationsRadiationPressure.h
@@ -92,12 +92,15 @@ inline MiscAccelerationsRadiationPressure::MiscAccelerationsRadiationPressure(Co
   {
     FileName fileNameInAlbedo, fileNameInFlux;
 
+    renameDeprecatedConfig(config, "factorSolarRadation", "factorSolarRadiation", date2time(2026, 7, 6));
+    renameDeprecatedConfig(config, "factorEarthRadation", "factorEarthRadiation",   date2time(2026, 7, 6));
+
     readConfig(config, "solarflux",                       solarflux,        Config::DEFAULT,  "1367", "solar flux constant in 1 AU [W/m^2]");
     readConfig(config, "eclipse",                         eclipse,          Config::MUSTSET,  "",     "");
     readConfig(config, "inputfileAlbedoTimeSeries",       fileNameInAlbedo, Config::OPTIONAL, "{groopsDataDir}/earthRadiationPressure/CERES_SYN1deg_albedo_climatology.dat",       "GriddedDataTimeSeries of albedo values (unitless)");
     readConfig(config, "inputfileLongwaveFluxTimeSeries", fileNameInFlux,   Config::OPTIONAL, "{groopsDataDir}/earthRadiationPressure/CERES_SYN1deg_longwaveFlux_climatology.dat", "GriddedDataTimeSeries of longwave flux values [W/m^2]");
-    readConfig(config, "factorSolarRadation",             factorSun,        Config::DEFAULT,  "1.0",  "Solar radiation pressure is multiplied by this factor");
-    readConfig(config, "factorEarthRadation",             factorEarth,      Config::DEFAULT,  "1.0",  "Earth radiation preussure is multiplied by this factor");
+    readConfig(config, "factorSolarRadiation",            factorSun,        Config::DEFAULT,  "1.0",  "Solar radiation pressure is multiplied by this factor");
+    readConfig(config, "factorEarthRadiation",            factorEarth,      Config::DEFAULT,  "1.0",  "Earth radiation preussure is multiplied by this factor");
     readConfig(config, "factorThermalRadiation",          factorThermal,    Config::DEFAULT,  "1.0",  "Thermal (re-)radiation is multiplied by this factor");
     if(isCreateSchema(config)) return;
 

--- a/source/programs/conversion/doodsonHarmonics/doodsonHarmonics2IersPotential.cpp
+++ b/source/programs/conversion/doodsonHarmonics/doodsonHarmonics2IersPotential.cpp
@@ -50,8 +50,10 @@ void DoodsonHarmonics2IersPotential::run(Config &config, Parallel::CommunicatorP
     UInt        minDegree, maxDegree = INFINITYDEGREE;
     std::vector<std::string> headers;
 
+    renameDeprecatedConfig(config, "inputfileDoodsonHarmoncis", "inputfileDoodsonHarmonics",   date2time(2026, 7, 6));
+
     readConfig(config, "outputfile",                       fileNameOut, Config::MUSTSET,  "","according to IERS2010, chapter 6.3.2, footnote 7");
-    readConfig(config, "inputfileDoodsonHarmoncis",        fileNameIn,  Config::MUSTSET,  "", "");
+    readConfig(config, "inputfileDoodsonHarmonics",        fileNameIn,  Config::MUSTSET,  "", "");
     readConfig(config, "header",                           headers,     Config::MUSTSET,  R"|(["Coefficients to compute variations in normalized Stokes coefficients (unit = 10^-11)", "Ocean tide model: FES2014b up to (100,100) in cm"])|", "info for output header");
     readConfig(config, "factor",                           factor,      Config::DEFAULT,  "1e11", "");
     readConfig(config, "minDegree",                        minDegree,   Config::DEFAULT,  "1",    "");

--- a/source/programs/conversion/doodsonHarmonics/doodsonHarmonics2IersWaterHeight.cpp
+++ b/source/programs/conversion/doodsonHarmonics/doodsonHarmonics2IersWaterHeight.cpp
@@ -52,8 +52,10 @@ void DoodsonHarmonics2IersWaterHeight::run(Config &config, Parallel::Communicato
     UInt        minDegree, maxDegree = INFINITYDEGREE;
     std::vector<std::string> headers;
 
+    renameDeprecatedConfig(config, "inputfileDoodsonHarmoncis", "inputfileDoodsonHarmonics",   date2time(2026, 7, 6));
+
     readConfig(config, "outputfile",                       fileNameOut, Config::MUSTSET,  "","according to IERS2010, chapter 6.3.2, footnote 7");
-    readConfig(config, "inputfileDoodsonHarmoncis",        fileNameIn,  Config::MUSTSET,  "", "");
+    readConfig(config, "inputfileDoodsonHarmonics",        fileNameIn,  Config::MUSTSET,  "", "");
     readConfig(config, "inputfileTideGeneratingPotential", fileNameTGP, Config::MUSTSET,  "{groopsDataDir}/tides/generatingTide_HW95.txt", "to compute Xi phase correction");
     readConfig(config, "header",                           headers,     Config::MUSTSET,  "Ocean tide model: FES2014b up to (100,100) in cm", "info for output header");
     readConfig(config, "kernel",                           kernel,      Config::MUSTSET,  "waterHeight", "data type of output values");

--- a/source/programs/conversion/doodsonHarmonics/iersPotential2DoodsonHarmonics.cpp
+++ b/source/programs/conversion/doodsonHarmonics/iersPotential2DoodsonHarmonics.cpp
@@ -46,7 +46,9 @@ void IersPotential2DoodsonHarmonics::run(Config &config, Parallel::CommunicatorP
     Double    GM, R;
     UInt      minDegree, maxDegree = INFINITYDEGREE;
 
-    readConfig(config, "outputfileDoodsonHarmoncis", fileNameOut, Config::MUSTSET, "",  "");
+    renameDeprecatedConfig(config, "outputfileDoodsonHarmoncis", "outputfileDoodsonHarmonics",   date2time(2026, 7, 6));
+
+    readConfig(config, "outputfileDoodsonHarmonics", fileNameOut, Config::MUSTSET, "",  "");
     readConfig(config, "inputfile",                  fileNameIn,  Config::MUSTSET, "",  "");
     readConfig(config, "headerLines",                countHeader, Config::MUSTSET, "4", "skip number of header lines");
     readConfig(config, "minDegree",                  minDegree,   Config::DEFAULT, "0", "");

--- a/source/programs/conversion/doodsonHarmonics/iersWaterHeight2DoodsonHarmonics.cpp
+++ b/source/programs/conversion/doodsonHarmonics/iersWaterHeight2DoodsonHarmonics.cpp
@@ -50,7 +50,9 @@ void IersWaterHeight2DoodsonHarmonics::run(Config &config, Parallel::Communicato
     Double    GM, R;
     UInt      minDegree, maxDegree = INFINITYDEGREE;
 
-    readConfig(config, "outputfileDoodsonHarmoncis",       fileNameOut, Config::MUSTSET, "",  "");
+    renameDeprecatedConfig(config, "outputfileDoodsonHarmoncis", "outputfileDoodsonHarmonics",   date2time(2026, 7, 6));
+
+    readConfig(config, "outputfileDoodsonHarmonics",       fileNameOut, Config::MUSTSET, "",  "");
     readConfig(config, "inputfile",                        fileNameIn,  Config::MUSTSET, "",  "");
     readConfig(config, "headerLines",                      countHeader, Config::MUSTSET, "3", "skip number of header lines");
     readConfig(config, "inputfileTideGeneratingPotential", fileNameTGP, Config::MUSTSET, "{groopsDataDir}/tides/generatingTide_HW95.txt", "to compute Xi phase correction");

--- a/source/programs/conversion/gnss/gnssReceiver2RinexObservation.cpp
+++ b/source/programs/conversion/gnss/gnssReceiver2RinexObservation.cpp
@@ -52,12 +52,14 @@ void GnssReceiver2RinexObservation::run(Config &config, Parallel::CommunicatorPt
     std::vector<std::string> comments;
     std::vector<GnssType> useType, ignoreType;
 
+    renameDeprecatedConfig(config, "angency", "agency",   date2time(2026, 7, 6));
+
     readConfig(config, "outputfileRinexObservation", fileNameOut,      Config::MUSTSET,  "",    "RINEX observation file");
     readConfig(config, "inputfileGnssReceiver",      fileNameObs,      Config::MUSTSET,  "",    "GNSS instrument file");
     readConfig(config, "inputfileStationInfo",       fileNamePlatform, Config::MUSTSET,  "",    "antenna and receiver info");
     readConfig(config, "comment",                    comments,         Config::OPTIONAL, "",    "write comments at begin of header");
     readConfig(config, "observer",                   observer,         Config::OPTIONAL, "TUG", "header information");
-    readConfig(config, "angency",                    angency,          Config::OPTIONAL, "TUG", "header information");
+    readConfig(config, "agency",                     angency,          Config::OPTIONAL, "TUG", "header information");
     readConfig(config, "useType",                    useType,          Config::OPTIONAL, "",    "only use observations that match any of these patterns");
     readConfig(config, "ignoreType",                 ignoreType,       Config::OPTIONAL, "",    "ignore observations that match any of these patterns");
     if(isCreateSchema(config)) return;

--- a/source/programs/misc/kernel2Coefficients.cpp
+++ b/source/programs/misc/kernel2Coefficients.cpp
@@ -48,10 +48,12 @@ void Kernel2Coefficients::run(Config &config, Parallel::CommunicatorPtr /*comm*/
     Double    R, H;
     UInt      minDegree, maxDegree;
 
+    renameDeprecatedConfig(config, "maxDegre", "maxDegree",   date2time(2026, 7, 6));
+
     readConfig(config, "outputfileMatrix", fileNameOut,  Config::MUSTSET, "",  "matrix with columns degree, coefficients and inverse coefficients");
     readConfig(config, "kernel",           kernel,       Config::MUSTSET, "",  "");
     readConfig(config, "minDegree",        minDegree,    Config::DEFAULT, "0", "minimum degree of returned coefficients");
-    readConfig(config, "maxDegre",         maxDegree,    Config::MUSTSET, "",  "compute coefficients up to maxDegree");
+    readConfig(config, "maxDegree",        maxDegree,    Config::MUSTSET, "",  "compute coefficients up to maxDegree");
     readConfig(config, "height",           H,            Config::DEFAULT, "0", "evaluate kernel at R+height [m]");
     readConfig(config, "R",                R,            Config::DEFAULT, STRING_DEFAULT_R,  "reference radius");
     if(isCreateSchema(config)) return;

--- a/source/programs/misc/satelliteModelCreate.cpp
+++ b/source/programs/misc/satelliteModelCreate.cpp
@@ -140,6 +140,9 @@ template<> Bool readConfig(Config &config, const std::string &name, std::vector<
     if(!readConfigSequence(config, name, mustSet, defaultValue, annotation))
       return FALSE;
 
+    renameDeprecatedConfig(config, "reflexionInfrared", "reflectionInfrared", date2time(2026, 7, 6));
+    renameDeprecatedConfig(config, "reflexionVisible", "reflectionVisible",   date2time(2026, 7, 6));
+
     FileName fileNameIn;
     ExpressionVariablePtr typeExpr, areaExpr;
     ExpressionVariablePtr normalXExpr, normalYExpr, normalZExpr;
@@ -153,10 +156,10 @@ template<> Bool readConfig(Config &config, const std::string &name, std::vector<
     readConfig(config, "normalX",              normalXExpr,              Config::MUSTSET, "data1",  "");
     readConfig(config, "normalY",              normalYExpr,              Config::MUSTSET, "data2",  "");
     readConfig(config, "normalZ",              normalZExpr,              Config::MUSTSET, "data3",  "");
-    readConfig(config, "reflexionVisible",     reflexionVisibleExpr,     Config::MUSTSET, "data4",  "");
+    readConfig(config, "reflectionVisible",    reflexionVisibleExpr,     Config::MUSTSET, "data4",  "");
     readConfig(config, "diffusionVisible",     diffusionVisibleExpr,     Config::MUSTSET, "data5",  "");
     readConfig(config, "absorptionVisible",    absorptionVisibleExpr,    Config::MUSTSET, "data6",  "");
-    readConfig(config, "reflexionInfrared",    reflexionInfraredExpr,    Config::MUSTSET, "data7",  "");
+    readConfig(config, "reflectionInfrared",   reflexionInfraredExpr,    Config::MUSTSET, "data7",  "");
     readConfig(config, "diffusionInfrared",    diffusionInfraredExpr,    Config::MUSTSET, "data8",  "");
     readConfig(config, "absorptionInfrared",   absorptionInfraredExpr,   Config::MUSTSET, "data9",  "");
     readConfig(config, "specificHeatCapacity", specificHeatCapacityExpr, Config::MUSTSET, "data10", "0: no thermal radiation, -1: direct reemission [Ws/K/m^2]");


### PR DESCRIPTION
Dear GROOPS Team, 

I came across a few typos in config elements after running a spellcheck on the codebase (i.e. all config-constructors for classes and programs). This PR renames all the affected config elements.

Best,
Andreas